### PR TITLE
Fix the cancellation of dleyna_gasync_task_t tasks

### DIFF
--- a/libdleyna/renderer/gasync-task.h
+++ b/libdleyna/renderer/gasync-task.h
@@ -36,7 +36,6 @@ const char *dleyna_gasync_task_create_source(void);
 void dleyna_gasync_task_add(const dleyna_task_queue_key_t *queue_id,
 		dleyna_gasync_task_action action,
 		GObject *target,
-		GAsyncReadyCallback callback,
 		GCancellable *cancellable,
 		GDestroyNotify free_func,
 		gpointer cb_user_data);


### PR DESCRIPTION
When a GAsyncResult-based asynchronous operation is cancelled, by
convention, it will always asynchronously invoke the
GAsyncReadyCallback with the error set to G_IO_ERROR_CANCELLED.
However, when the queues in a dleyna_task_processor_t are cancelled,
the tasks within them are immediately destroyed. This means that a
GAsyncReadyCallback shouldn't try to access a task after cancellation
because it would be pointing to invalid memory.

Here's an example:
```
%0  prv_introspect_rc_cb (target=0x556be880d9f0,
                          res=0x556be8840280,
                          user_data=0x556be88fef70)
    at device.c:835
%1  dleyna_gasync_task_ready_cb (source=<optimized out>,
                                 res=<optimized out>,
                                 user_data=0x556be89a0ac0)
    at gasync-task.c:75
%2  g_task_return_now (task=0x556be8840280) at ../gio/gtask.c:1215
%3  complete_in_idle_cb (task=task@entry=0x556be8840280)
    at ../gio/gtask.c:1229
%4  g_idle_dispatch (source=source@entry=0x556be8844e40,
                     callback=0x7f87cd82b380 <complete_in_idle_cb>,
                     user_data=0x556be8840280)
    at ../glib/gmain.c:5836
%5  g_main_dispatch (context=0x556be87e6be0) at ../glib/gmain.c:3325
%6  g_main_context_dispatch (context=0x556be87e6be0)
    at ../glib/gmain.c:4043
%7  g_main_context_iterate.constprop.0 (context=0x556be87e6be0,
                                        block=block@entry=1,
                                        dispatch=dispatch@entry=1,
                                        self=<optimized out>)
    at ../glib/gmain.c:4119
%8  g_main_loop_run (loop=0x556be8828130) at ../glib/gmain.c:4317
%9  dleyna_main_loop_start (server=<optimized out>,
                            control_point=<optimized out>,
                            user_data=<optimized out>)
    at libdleyna/core/main-loop.c:154
%10 __libc_start_main (main=0x556be79fe0d0 <main>,
                       argc=1, argv=0x7ffeb4610d98,
                       init=<optimized out>,
                       fini=<optimized out>,
                       rtld_fini=<optimized out>,
                       stack_end=0x7ffeb4610d88)
    at ../csu/libc-start.c:314
%11 0x0000556be79fe14e in _start ()
```

Till now, dleyna_gasync_task_ready_cb was being used as the common
GAsyncReadyCallback for all tasks. However, it doesn't support
cancellation because that requires the use of the 'finish' counterpart
of the specific asynchronous operation in question. Therefore, instead
of a common GAsyncReadyCallback, each task needs to provide its own.

Secondly, when cancelling a dleyna_gasync_task_t through
dleyna_gasync_task_cancel_cb, dleyna_task_queue_task_completed should
be called only if the task was current. Calling it for tasks that were
waiting in the queue breaks the semantics of the processor because the
running_tasks counter is an unsigned integer and can't accommodate
negative values.

https://bugzilla.redhat.com/show_bug.cgi?id=1900645